### PR TITLE
hotfix(v1.0.19a): Resolves block rendering

### DIFF
--- a/includes/BlockFrontend/AbstractBlockRender.php
+++ b/includes/BlockFrontend/AbstractBlockRender.php
@@ -10,7 +10,7 @@ abstract class AbstractBlockRender
    * @param array $attributes A clean associative array of block attributes.
    * @param string $innerBlocks All the inner block semantics.
    */
-  abstract public function render($attributes, $innerBlocks): string;
+  abstract public function render($attributes, $innerBlocks, ?\WP_Block $block = null): string;
 }
 
 

--- a/includes/BlockFrontend/Accordion.php
+++ b/includes/BlockFrontend/Accordion.php
@@ -10,8 +10,12 @@ class Accordion extends AbstractBlockRender
     /**
      * @inheritDoc
      */
-    public function render($attributes, $innerBlocks): string
+    public function render($attributes, $innerBlocks, ?\WP_Block $block = null): string
     {
+        if ( $block && ! empty( trim($block->inner_html )) ) {
+            return $innerBlocks;
+        }
+
       // Attributes
       $same_block_count     = isset( $attributes['sameBlockCount'] )     ? (int) $attributes['sameBlockCount']     : 0;
       $total_children_count = isset( $attributes['totalChildrenCount'] ) ? (int) $attributes['totalChildrenCount'] : 0;

--- a/includes/BlockFrontend/Accordions.php
+++ b/includes/BlockFrontend/Accordions.php
@@ -10,8 +10,11 @@ class Accordions extends AbstractBlockRender
     /**
      * @inheritDoc
      */
-    public function render($attributes, $innerBlocks): string
+    public function render($attributes, $innerBlocks, ?\WP_Block $block = null): string
     {
+        if ( $block && ! empty( trim($block->inner_html )) ) {
+            return $innerBlocks;
+        }
         $wrapper_class = $attributes['className'] ?? '';
 
         $markup  = '<div class="' . esc_attr( trim( $wrapper_class ) ) . '">';

--- a/includes/BlockFrontend/Alert.php
+++ b/includes/BlockFrontend/Alert.php
@@ -9,7 +9,7 @@ class Alert extends AbstractBlockRender
     /**
      * @inheritDoc
      */
-    public function render($attributes = [], $innerBlocks = ''): string
+    public function render($attributes = [], $innerBlocks = '', ?\WP_Block $block = null): string
     {
       $style = isset($attributes['style']) ? esc_attr($attributes['style']) : 'default';
       $title = isset($attributes['title']) ? esc_attr($attributes['title']) : '';

--- a/includes/BlockFrontend/CallToAction.php
+++ b/includes/BlockFrontend/CallToAction.php
@@ -10,7 +10,7 @@ class CallToAction extends AbstractBlockRender
   /**
    * @inheritDoc
    */
-  public function render($attributes, $innerBlocks): string
+  public function render($attributes, $innerBlocks, ?\WP_Block $block = null): string
   {
     $wrapper_class = $attributes['className'] ?? '';
 

--- a/includes/BlockFrontend/Collapse.php
+++ b/includes/BlockFrontend/Collapse.php
@@ -11,8 +11,12 @@ class Collapse extends AbstractBlockRender
   /**
    * @inheritDoc
    */
-  public function render($attributes, $innerBlocks): string
+  public function render($attributes, $innerBlocks, ?\WP_Block $block = null): string
   {
+      if ( $block && ! empty( trim($block->inner_html )) ) {
+          return $innerBlocks;
+      }
+
     $color = isset($attributes['color']) ? sanitize_html_class($attributes['color']) : '';
     $title = isset($attributes['title']) ? wp_kses_post($attributes['title']) : '';
     $jump_name = isset($attributes['jumpName']) ? $attributes['jumpName'] : '';
@@ -21,7 +25,6 @@ class Collapse extends AbstractBlockRender
     $svg_class = isset($attributes['svgString']) ? sanitize_html_class($attributes['svgString']) : '';
     $svg_class = preg_replace('/(fa-(solid|regular|brands))(fa-)/', '$1 $3', $svg_class);
 
-    Helper::debug($svg_class);
 
     $wrapper_class = isset($attributes['className']) ? $attributes['className'] : '';
 

--- a/includes/BlockFrontend/Collapsibles.php
+++ b/includes/BlockFrontend/Collapsibles.php
@@ -3,6 +3,7 @@
 namespace RRZE\ElementsBlocks\BlockFrontend;
 
 use RRZE\ElementsBlocks\BlockFrontend\AbstractBlockRender;
+use RRZE\ElementsBlocks\Helper;
 
 class Collapsibles extends AbstractBlockRender
 {
@@ -10,7 +11,12 @@ class Collapsibles extends AbstractBlockRender
     /**
      * @inheritDoc
      */
-  public function render( $attributes = [], $innerBlocks = '' ) : string {
+  public function render( $attributes = [], $innerBlocks = '', ?\WP_Block $block = null) : string {
+
+      if ( $block && ! empty( trim($block->inner_html )) ) {
+          return $innerBlocks;
+      }
+
     $expand_all_link = ! empty( $attributes['expandAllLink'] );
     $expand_label    = $attributes['expandLabel'] ?? '';
 

--- a/includes/BlockFrontend/Columns.php
+++ b/includes/BlockFrontend/Columns.php
@@ -10,7 +10,7 @@ class Columns extends AbstractBlockRender
   /**
    * @inheritDoc
    */
-  public function render($attributes, $innerBlocks): string
+  public function render($attributes, $innerBlocks, ?\WP_Block $block = null): string
   {
     $wrapper_class = 'elements-textcolumns' . (!empty($attributes['className']) ? ' ' . $attributes['className'] : '');
 

--- a/includes/BlockFrontend/ContentWidthLimiter.php
+++ b/includes/BlockFrontend/ContentWidthLimiter.php
@@ -10,7 +10,7 @@ class ContentWidthLimiter extends AbstractBlockRender
   /**
    * @inheritDoc
    */
-  public function render($attributes, $innerBlocks): string
+  public function render($attributes, $innerBlocks, ?\WP_Block $block = null): string
   {
     $width = isset($attributes['width']) ? (int)$attributes['width'] : 0;
     $character_width = round($width * 0.125);

--- a/includes/BlockFrontend/Counter.php
+++ b/includes/BlockFrontend/Counter.php
@@ -10,7 +10,7 @@ class Counter extends AbstractBlockRender
     /**
      * @inheritDoc
      */
-    public function render($attributes, $innerBlocks): string
+    public function render($attributes, $innerBlocks, ?\WP_Block $block = null): string
     {
       $wrapper_class = $attributes['className'] ?? '';
 

--- a/includes/BlockFrontend/CounterRow.php
+++ b/includes/BlockFrontend/CounterRow.php
@@ -27,7 +27,7 @@ class CounterRow extends AbstractBlockRender
   /**
    * @inheritDoc
    */
-  public function render($attributes, $innerBlocks): string
+  public function render($attributes, $innerBlocks, ?\WP_Block $block = null): string
   {
     $innerBlocks = $this->strip_legacy_wrapper( $innerBlocks );
 

--- a/includes/BlockFrontend/IconBox.php
+++ b/includes/BlockFrontend/IconBox.php
@@ -10,7 +10,7 @@ class IconBox extends AbstractBlockRender
   /**
    * @inheritDoc
    */
-  public function render($attributes, $innerBlocks): string
+  public function render($attributes, $innerBlocks, ?\WP_Block $block = null): string
   {
     $title = $attributes['title'] ?? '';
     $description = $attributes['description'] ?? '';

--- a/includes/BlockFrontend/Insertion.php
+++ b/includes/BlockFrontend/Insertion.php
@@ -10,7 +10,7 @@ class Insertion extends AbstractBlockRender
     /**
      * @inheritDoc
      */
-    public function render($attributes, $innerBlocks): string
+    public function render($attributes, $innerBlocks, ?\WP_Block $block = null): string
     {
       $alignment   = $attributes['alignment'] ?? '';
       $extra_class = $attributes['className'] ?? '';

--- a/includes/BlockFrontend/Notice.php
+++ b/includes/BlockFrontend/Notice.php
@@ -25,8 +25,12 @@ class Notice extends AbstractBlockRender
     /**
      * @inheritDoc
      */
-    public function render($attributes, $innerBlocks): string
+    public function render($attributes, $innerBlocks, ?\WP_Block $block = null): string
     {
+      if ( $block && ! empty( trim($block->inner_html )) ) {
+        return $innerBlocks;
+      }
+
       $variation   = isset( $attributes['style'] ) ? $attributes['style'] : '';
       $icon_class  = self::$icon_map[ $variation ] ?? '';
 

--- a/includes/BlockFrontend/Tab.php
+++ b/includes/BlockFrontend/Tab.php
@@ -10,7 +10,7 @@ class Tab extends AbstractBlockRender
     /**
      * @inheritDoc
      */
-    public function render($attributes, $innerBlocks): string
+    public function render($attributes, $innerBlocks, ?\WP_Block $block = null): string
     {
       $tabs_uid      = isset($attributes['tabsUid']) ? $attributes['tabsUid'] : '';
       $block_id      = isset($attributes['blockId']) ? $attributes['blockId'] : '';

--- a/includes/BlockFrontend/Tabs.php
+++ b/includes/BlockFrontend/Tabs.php
@@ -10,7 +10,7 @@ class Tabs extends AbstractBlockRender
     /**
      * @inheritDoc
      */
-    public function render($attributes, $innerBlocks): string
+    public function render($attributes, $innerBlocks, ?\WP_Block $block = null): string
     {
       $wrapper_class = $attributes['className'] ?? '';
       $color         = isset($attributes['color']) ? sanitize_html_class($attributes['color']) : '';

--- a/includes/BlockFrontend/Timeline.php
+++ b/includes/BlockFrontend/Timeline.php
@@ -10,7 +10,7 @@ class Timeline extends AbstractBlockRender
     /**
      * @inheritDoc
      */
-    public function render($attributes, $innerBlocks): string
+    public function render($attributes, $innerBlocks, ?\WP_Block $block = null): string
     {
       $wrapper_class = isset($attributes['className']) ? $attributes['className'] : '';
 

--- a/includes/BlockFrontend/TimelineItem.php
+++ b/includes/BlockFrontend/TimelineItem.php
@@ -10,7 +10,7 @@ class TimelineItem extends AbstractBlockRender
     /**
      * @inheritDoc
      */
-    public function render($attributes, $innerBlocks): string
+    public function render($attributes, $innerBlocks, ?\WP_Block $block = null): string
     {
       $wrapper_class = $attributes['className'] ?? '';
 

--- a/includes/Blocks.php
+++ b/includes/Blocks.php
@@ -140,21 +140,22 @@ class Blocks
       ]
     ];
 
-    foreach ($dynamic_blocks as $block) {
+    foreach ( $dynamic_blocks as $block_def ) {
       register_block_type(
-        plugin_dir_path(__DIR__) . 'build/blocks/' . $block['build_folder'],
+        plugin_dir_path( __DIR__ ) . 'build/blocks/' . $block_def['build_folder'],
         [
-          'render_callback' => function ($attributes, $block_info, $content) use ($block) {
-            $class = $block['class'];
+          'render_callback' => function ( $attributes, $content, $block ) use ( $block_def ) {
+            $class    = $block_def['class'];
             $instance = new $class();
-            return $instance->render($attributes, $block_info, $content);
+
+            return $instance->render( $attributes, $content, $block );
           },
         ]
       );
 
       load_plugin_textdomain('rrze-elements-blocks', false, dirname(plugin_basename(__DIR__)) . 'languages');
 
-      $script_handle = generate_block_asset_handle('rrze-elements/' . $block['build_folder'], 'editorScript');
+      $script_handle = generate_block_asset_handle('rrze-elements/' . $block_def['build_folder'], 'editorScript');
       wp_set_script_translations($script_handle, 'rrze-elements-blocks', plugin_dir_path(__DIR__) . 'languages');
     }
   }

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: blocks, gutenberg, design, elements
 Requires at least: 6.0
 Tested up to: 6.8
 Requires PHP: 8.0
-Stable tag: 1.0.19
+Stable tag: 1.0.20
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 

--- a/rrze-elements-blocks.php
+++ b/rrze-elements-blocks.php
@@ -4,7 +4,7 @@
 Plugin Name:     RRZE Elements Blocks
 Plugin URI:      https://github.com/RRZE-Webteam/rrze-elements
 Description:     Advanced design elements for WordPress BlockEditor.
-Version:         1.0.19
+Version:         1.0.20
 Author:          RRZE Webteam
 Author URI:      https://blogs.fau.de/webworking/
 License:         GNU General Public License v2


### PR DESCRIPTION
Updates block rendering logic to handle legacy content issues.

This change introduces a new parameter to the `render` method in `AbstractBlockRender` and its implementations. The new parameter allows the render callback to access the block instance.
Several blocks now check if the block has inner HTML and return the inner blocks directly to properly render the legacy content.
